### PR TITLE
Mod: reject ~ postfixed files found in repos_conf (aka backup files) from processing

### DIFF
--- a/main.c
+++ b/main.c
@@ -504,6 +504,10 @@ read_repos_conf(const char *configroot, const char *repos_conf)
 			if (name[0] == '.')
 				continue;
 
+			/* Exclude backup files (aka files with ~ as postfix). */
+			if (name[0] != '\0' && name[strlen(name) - 1] == '~')
+				continue;
+
 #ifdef DT_UNKNOWN
 			if (confs[i]->d_type != DT_UNKNOWN &&
 			    confs[i]->d_type != DT_REG &&


### PR DESCRIPTION
Hello,

I see that when executing `q -r` to update the cache, all files found in the directory specified by the variable repos_conf (main.c:487 i.e. /etc/portage/repos.conf) are processed to retrieve information about the repos (i.e. location), except the files whose name begins with a '.' dot.

In my humble opinion, files postfixed with a '~' tilde should also be excluded from processing, since they are obviously backup file -- Emacs is known to create such backup files after editing a file.

Here I propose a patch to change the behaviour of `q` and exclude backup files found in repos_conf from processing (aka files postfixed with ~).

Please, let me know if my suggestion is appropriate.

Thanks.