### PR TITLE
Qtegrity fix filesize check

### DIFF
--- a/qfile.c
+++ b/qfile.c
@@ -41,6 +41,7 @@ typedef struct {
 	char **dirnames;
 	char **realdirnames;
 	short *non_orphans;
+//	int *results;
 } qfile_args_t;
 
 struct qfile_opt_state {
@@ -60,6 +61,64 @@ struct qfile_opt_state {
 	bool orphans;
 	bool assume_root_prefix;
 };
+
+/*
+ * As a final step, check if file is in the plib_reg
+ */
+static int qfile_check_plibreg(void *priv)
+{
+	struct qfile_opt_state *state = priv;
+
+	int fd_plibreg;
+        FILE *fp_plibreg;
+	struct stat cst;
+
+	/* Open plibreg */
+        fp_plibreg = NULL;
+	fd_plibreg = open("/var/lib/portage/preserved_libs_registry", O_RDONLY|O_CLOEXEC, 0);
+	if (fd_plibreg == -1)
+		return 0;
+	if (fstat(fd_plibreg, &cst)) {
+		close(fd_plibreg);
+		return 0;
+	}
+	if ((fp_plibreg = fdopen(fd_plibreg, "r")) == NULL) {
+		close(fd_plibreg);
+		return 0;
+	}
+
+        qfile_args_t *args = &state->args;
+        char **base_names = args->basenames;
+        char **dir_names = args->dirnames;
+        short *non_orphans = args->non_orphans;
+	char file[_Q_PATH_MAX];
+	char *line = NULL;
+	size_t len = 0;
+	int found = 0;
+
+	for (int i = 0; i < args->length; i++) {
+		if (base_names[i] == NULL)
+			continue;
+		if (non_orphans && non_orphans[i])
+			continue;
+
+		snprintf(file, sizeof(file), "%s/%s", dir_names[i], base_names[i]);
+
+		while (getline(&line, &len, fp_plibreg) != -1)
+			if (strstr(line, file) != NULL) {
+				found++;
+				if (quiet)
+					puts("");
+				else
+					printf("%s%splib_registry%s (%s)\n", BOLD, BLUE, NORM, file);
+			}
+	}
+
+	if (line)
+		free(line);
+
+	return found;
+}
 
 /*
  * We assume the people calling us have chdir(/var/db/pkg) and so
@@ -233,7 +292,7 @@ static int qfile_cb(q_vdb_pkg_ctx *pkg_ctx, void *priv)
 			} else {
 				non_orphans[i] = 1;
 			}
-			found++;
+			found++; //TODO @SAM, maybe this should actually be stored? e.g. state->results[i] = 1
 		}
 	}
 	fclose(fp);
@@ -262,6 +321,7 @@ static void destroy_qfile_args(qfile_args_t *qfile_args)
 	free(qfile_args->dirnames);
 	free(qfile_args->realdirnames);
 	free(qfile_args->non_orphans);
+//	free(qfile_args->results);
 
 	memset(qfile_args, 0, sizeof(qfile_args_t));
 }
@@ -278,6 +338,7 @@ prepare_qfile_args(const int argc, const char **argv, struct qfile_opt_state *st
 	char **basenames = NULL;
 	char **dirnames = NULL;
 	char **realdirnames = NULL;
+//	int *results = NULL;
 	char tmppath[_Q_PATH_MAX+1];
 	char abspath[_Q_PATH_MAX+1];
 
@@ -289,8 +350,11 @@ prepare_qfile_args(const int argc, const char **argv, struct qfile_opt_state *st
 	basenames = xcalloc(argc, sizeof(char*));
 	dirnames = xcalloc(argc, sizeof(char*));
 	realdirnames = xcalloc(argc, sizeof(char*));
+//	results = xcalloc(argc, sizeof(int));
 
 	for (i = 0; i < argc; ++i) {
+//		results[i] = 0;
+
 		/* Record basename, but if it is ".", ".." or "/" */
 		/* strncopy so that "argv" can be "const" */
 		strncpy(abspath, argv[i], _Q_PATH_MAX);
@@ -389,6 +453,7 @@ prepare_qfile_args(const int argc, const char **argv, struct qfile_opt_state *st
 	args->dirnames = dirnames;
 	args->realdirnames = realdirnames;
 	args->length = argc;
+//	args->results = results;
 
 	if (state->orphans)
 		args->non_orphans = xcalloc(argc, sizeof(short));
@@ -474,9 +539,14 @@ int qfile_main(int argc, char **argv)
 
 	/* Prepare the qfile(...) arguments structure */
 	nb_of_queries = prepare_qfile_args(argc, (const char **) argv, &state);
+
 	/* Now do the actual `qfile` checking */
 	if (nb_of_queries > 0)
 		found += q_vdb_foreach_pkg_sorted(qfile_cb, &state);
+
+	/* Also check plib_reg */
+	if (nb_of_queries > 0)
+		found += qfile_check_plibreg(&state);
 
 	if (state.args.non_orphans) {
 		/* display orphan files */

--- a/qtegrity.c
+++ b/qtegrity.c
@@ -245,9 +245,7 @@ static int get_size_digest(char * line)
 
 static int check_file(char * filename)
 {
-	/* TODO, this is 4096 too low, because this variable also holds
-	 * path; for linux path is max 4096 chars */
-	if (strlen(filename) > 255)
+	if (strlen(filename) > _Q_PATH_MAX)
 		err("Filename too long");
 
 	if (filename[0] != '/') {


### PR DESCRIPTION
check_file() had a strlen check on 255, which was 4096 too low. Changed this to check on _Q_PATH_MAX which is used throughout portage-utils for this exact purpose.