### PR TITLE
*: simplify code by taking advantage of implicit initialization

### DIFF
--- a/qcheck.c
+++ b/qcheck.c
@@ -384,14 +384,10 @@ int qcheck_main(int argc, char **argv)
 	struct qcheck_opt_state state = {
 		.atoms = atoms,
 		.regex_arr = regex_arr,
-		.bad_only = false,
-		.qc_update = false,
 		.chk_afk = true,
 		.chk_hash = true,
 		.chk_mtime = true,
 		.chk_config_protect = true,
-		.undo_prelink = false,
-		.fmt = NULL,
 	};
 
 	while ((ret = GETOPT_LONG(QCHECK, qcheck, "")) != -1) {

--- a/qdepends.c
+++ b/qdepends.c
@@ -289,9 +289,7 @@ int qdepends_main(int argc, char **argv)
 		.atoms = atoms,
 		.deps = deps,
 		.udeps = create_set(),
-		.qmode = 0,
 		.format = "%[CATEGORY]%[PF]",
-		.vdb = NULL,
 	};
 	size_t i;
 	int ret;

--- a/qfile.c
+++ b/qfile.c
@@ -478,12 +478,6 @@ int qfile_main(int argc, char **argv)
 {
 	struct qfile_opt_state state = {
 		.buflen = _Q_PATH_MAX,
-		.need_full_atom = false,
-		.basename = false,
-		.orphans = false,
-		.assume_root_prefix = false,
-		.skip_plibreg = false,
-		.format = NULL,
 	};
 	int i, nb_of_queries, found = 0;
 	char *p;

--- a/qgrep.c
+++ b/qgrep.c
@@ -447,22 +447,8 @@ int qgrep_main(int argc, char **argv)
 	char *overlay;
 
 	struct qgrep_grepargs args = {
-		.do_count = false,
-		.do_regex = false,
-		.do_list = false,
 		.show_filename = true,
-		.show_name = false,
-		.skip_comments = false,
-		.invert_list = false,
-		.invert_match = false,
-		.skip_pattern = NULL,
-		.num_lines_before = 0,
-		.num_lines_after = 0,
-		.buf_list = NULL,
-		.query = NULL,
 		.strfunc = strstr,
-		.include_atoms = NULL,
-		.portdir = NULL,
 	};
 
 	do_eclass = do_installed = 0;

--- a/qlist.c
+++ b/qlist.c
@@ -412,18 +412,7 @@ int qlist_main(int argc, char **argv)
 	struct qlist_opt_state state = {
 		.argc = argc,
 		.argv = argv,
-		.exact = false,
-		.all = false,
-		.do_binpkgs = false,
-		.just_pkgname = false,
-		.show_dir = false,
-		.show_obj = false,
-		.show_sym = false,
-		.need_full_atom = false,
-		.show_umap = false,
-		.show_dbg = false,
 		.buflen = _Q_PATH_MAX,
-		.fmt = NULL,
 	};
 
 	while ((i = GETOPT_LONG(QLIST, qlist, "")) != -1) {

--- a/qlop.c
+++ b/qlop.c
@@ -1209,9 +1209,9 @@ int qlop_main(int argc, char **argv)
 {
 	size_t i;
 	int ret;
-	time_t start_time;
-	time_t end_time;
-	struct qlop_mode m;
+	time_t start_time = 0;
+	time_t end_time = LONG_MAX;
+	struct qlop_mode m = {};
 	char *logfile = NULL;
 	char *atomfile = NULL;
 	char *p;
@@ -1219,23 +1219,6 @@ int qlop_main(int argc, char **argv)
 	depend_atom *atom;
 	DECLARE_ARRAY(atoms);
 	int runningmode = 0;
-
-	start_time = 0;
-	end_time = LONG_MAX;
-	m.do_time = 0;
-	m.do_merge = 0;
-	m.do_unmerge = 0;
-	m.do_autoclean = 0;
-	m.do_sync = 0;
-	m.do_running = 0;
-	m.do_average = 0;
-	m.do_summary = 0;
-	m.do_human = 0;
-	m.do_machine = 0;
-	m.do_endtime = 0;
-	m.show_lastmerge = 0;
-	m.show_emerge = 0;
-	m.fmt = NULL;
 
 	while ((ret = GETOPT_LONG(QLOP, qlop, "")) != -1) {
 		switch (ret) {

--- a/qsearch.c
+++ b/qsearch.c
@@ -119,15 +119,7 @@ int qsearch_main(int argc, char **argv)
 	int i;
 	const char *overlay;
 	size_t n;
-	struct qsearch_state state = {
-		.show_homepage  = false,
-		.show_name      = false,
-		.show_desc      = false,
-		.search_desc    = false,
-		.search_name    = false,
-		.need_full_atom = false,
-		.fmt            = NULL,
-	};
+	struct qsearch_state state = {};
 
 	while ((i = GETOPT_LONG(QSEARCH, qsearch, "")) != -1) {
 		switch (i) {

--- a/qsize.c
+++ b/qsize.c
@@ -194,20 +194,8 @@ int qsize_main(int argc, char **argv)
 	DECLARE_ARRAY(atoms);
 	struct qsize_opt_state state = {
 		.atoms = atoms,
-		.search_all = 0,
-		.fs_size = 0,
-		.summary = 0,
-		.summary_only = 0,
-		.disp_units = 0,
-		.str_disp_units = NULL,
 		.ignore_regexp = ignore_regexp,
 		.uniq_files = create_set(),
-		.num_all_files = 0,
-		.num_all_nonfiles = 0,
-		.num_all_ignored = 0,
-		.num_all_bytes = 0,
-		.need_full_atom = false,
-		.fmt = NULL,
 	};
 
 	while ((ret = GETOPT_LONG(QSIZE, qsize, "")) != -1) {

--- a/qtegrity.c
+++ b/qtegrity.c
@@ -232,12 +232,6 @@ int qtegrity_main(int argc, char **argv)
 
 	struct qtegrity_opt_state state = {
 		.ima = true,
-		.add = false,
-		.ignore_non_exist = false,
-		.show_matches = false,
-/* TODO
-		.convert = false;
-*/
 	};
 
 	while ((i = GETOPT_LONG(QTEGRITY, qtegrity, "")) != -1) {

--- a/quse.c
+++ b/quse.c
@@ -648,15 +648,7 @@ int quse_main(int argc, char **argv)
 	const char *overlay;
 	char *match = NULL;
 	struct quse_state state = {
-		.do_all         = false,
-		.do_regex       = true,
-		.do_describe    = false,
-		.do_licence     = false,
-		.do_installed   = false,
-		.need_full_atom = false,
-		.match          = NULL,
-		.overlay        = NULL,
-		.fmt            = NULL,
+		.do_regex = true,
 	};
 
 	while ((i = GETOPT_LONG(QUSE, quse, "")) != -1) {


### PR DESCRIPTION
Per the C language specification, members of arrays, structs, and unions
not explicitly initialized in {} are implicitly initialized to zero.

Please merge. Thanks.