### PR TITLE
qlop: Fixed --running --verbose returning unknown ETA.

### DIFF
--- a/qlop.c
+++ b/qlop.c
@@ -797,7 +797,9 @@ static int do_emerge_log(
 							|| flags->do_running)
 					{
 						/* find in list of averages */
-						if (flags->do_predict || verbose) {
+						if (flags->do_predict ||
+							(verbose && !flags->do_running))
+						{
 							snprintf(afmt, sizeof(afmt), "%s/%s",
 									pkgw->atom->CATEGORY, pkgw->atom->PF);
 						} else {
@@ -940,7 +942,9 @@ static int do_emerge_log(
 							|| flags->do_running)
 					{
 						/* find in list of averages */
-						if (flags->do_predict || verbose) {
+						if (flags->do_predict ||
+							(verbose && !flags->do_running))
+						{
 							snprintf(afmt, sizeof(afmt), "%s/%s",
 									pkgw->atom->CATEGORY, pkgw->atom->PF);
 						} else {


### PR DESCRIPTION
It seems that this was broken during the introduction of `--predict` in commit 13402fbd8c51f7feedcc85f2f0815768ec45ee7a which caused keys of the `merge_averages` and `unmerge_averages` sets to include version information, whereas `--running` expects these not to include version information.

Bug: https://bugs.gentoo.org/807975
Signed-off-by: Jaak Ristioja &lt;jaak@ristioja.ee&gt;