### PR TITLE
qmerge: Add .xpak binpkg-multi-instance support

### DIFF
--- a/libq/tree.c
+++ b/libq/tree.c
@@ -1483,7 +1483,6 @@ tree_foreach_packages(tree_ctx *ctx, tree_pkg_cb callback, void *priv)
 		if (strcmp(p, "REPO") == 0) { /* from global section in older files */
 			ctx->repo = c;
 		} else if (strcmp(p, "CPV") == 0) {
-			meta.Q_CPV = c;
 			if (atom != NULL)
 				atom_implode(atom);
 			atom = atom_explode(c);
@@ -1511,15 +1510,9 @@ tree_foreach_packages(tree_ctx *ctx, tree_pkg_cb callback, void *priv)
 		match_key(PDEPEND);
 		match_key2(REPO, repository);
 		match_key(SIZE);
-		match_key(BDEPEND);
-		//
 		match_key(PATH);
 		match_key(BUILD_ID);
 		match_key(BUILD_TIME);
-		match_key(REQUIRES);
-		match_key(RESTRICT);
-		match_key2(PROVIDES, PROVIDE);
-		//
 #undef match_key
 #undef match_key2
 		}

--- a/libq/tree.h
+++ b/libq/tree.h
@@ -99,6 +99,13 @@ struct tree_pkg_meta {
 	char *Q_PROPERTIES;
 	char *Q_BDEPEND;
 	/* binpkgs/vdb */
+	//
+	char *Q_CPV;
+	char *Q_PATH;
+	char *Q_BUILD_ID;
+	char *Q_BUILD_TIME;
+	char *Q_REQUIRES;
+	//
 	char *Q_DEFINED_PHASES;
 	char *Q_REQUIRED_USE;
 	char *Q_CONTENTS;

--- a/libq/tree.h
+++ b/libq/tree.h
@@ -99,13 +99,9 @@ struct tree_pkg_meta {
 	char *Q_PROPERTIES;
 	char *Q_BDEPEND;
 	/* binpkgs/vdb */
-	//
-	char *Q_CPV;
 	char *Q_PATH;
 	char *Q_BUILD_ID;
 	char *Q_BUILD_TIME;
-	char *Q_REQUIRES;
-	//
 	char *Q_DEFINED_PHASES;
 	char *Q_REQUIRED_USE;
 	char *Q_CONTENTS;

--- a/qmerge.c
+++ b/qmerge.c
@@ -87,6 +87,7 @@ char force_download = 0;
 char follow_rdepends = 1;
 char qmerge_strict = 0;
 char update_only = 0;
+char binpkg_multi_instance = 0;
 bool debug = false;
 const char Packages[] = "Packages";
 
@@ -2024,6 +2025,12 @@ int qmerge_main(int argc, char **argv)
 		install = 1;
 
 	qmerge_strict = contains_set("strict", features) ? 1 : 0;
+
+	binpkg_multi_instance = contains_set("binpkg-multi-instance", features) ? 1 : 0;
+	if (binpkg_multi_instance) {
+		warn("FEATURES=binpkg-multi-instance is set, but the qmerge");
+		warn(" .xpak multi-directory structure support is in beta!!");
+	}
 
 	/* Short circut this. */
 	if (install && !pretend) {

--- a/qmerge.c
+++ b/qmerge.c
@@ -2026,8 +2026,9 @@ int qmerge_main(int argc, char **argv)
 
 	qmerge_strict = contains_set("strict", features) ? 1 : 0;
 
+	/* TODO: remove warning when satisfied with binpkg-multi-instance handling */
 	binpkg_multi_instance = contains_set("binpkg-multi-instance", features) ? 1 : 0;
-	if (binpkg_multi_instance) {
+	if (verbose > 1 && binpkg_multi_instance) {
 		warn("FEATURES=binpkg-multi-instance is set, but the qmerge");
 		warn(" .xpak multi-directory structure support is in beta!!");
 	}


### PR DESCRIPTION
The current implementation of Qmerge did not support FEATURES="binpkg-multi-instance" directory structures suitable for .xpak style packages. (ie: one subdirectory for each package, with package names of ATOM-BUILD_ID + .xpak extension).

old .tbz2 directory example:
/var/cache/binpkgs/
/var/cache/binpkgs/dev-util
/var/cache/binpkgs/dev-util/desktop-file-utils-0.26-r2.tbz2

binpkg-multi-instance Example:
/var/cache/binpkgs/
/var/cache/binpkgs/dev-libs
/var/cache/binpkgs/dev-libs/libpwquality
/var/cache/binpkgs/dev-libs/libpwquality/libpwquality-1.4.4-3.xpak
/var/cache/binpkgs/dev-libs/libpwquality/libpwquality-1.4.4-4.xpak

The logic was already in place to actually read, interpret, and extract these xpak files, BUT it did not know how to find them. Resulting in errors:

\# q merge -pO libpwquality
[R] dev-libs/libpwquality-1.4.4
qmerge: /var/cache/binpkgs/dev-libs/libpwquality-1.4.4.tbz2 appears not to be a valid tbz2 file

This patch adds support for the multi-dir structure, based on reading the /var/cache/binpkgs/Packages index cache store file for the particular Atom, detecting if the "PATH" variable exists in the index (it would not exist for an old .tbz2), then following this exact PATH to locate the binpkg instead of the old way of attempting to guess and reconstruct a path from its atom sub-components (since it would be impossible to know the BUILD_ID this way).

(This patch relies on using the Packages file to read PATH)
CPV: dev-libs/libpwquality-1.4.4
PATH: dev-libs/libpwquality/libpwquality-1.4.4-3.xpak

I have tested it both with and without binpkg-multi-instance, and it works for both, and a combination of the two. The existing tests/ scripts all seem to still pass.

I added a warning message to the qmerge_main() function to detect the FEATURES, but this detection is not tied to any actual logic currently. I just wanted a message so people take note, in case the patch is non-functional due to some edge case overlooked, for example there are still some inadequacies and inconsistencies: 

1 - always chooses the first match, instead of choosing the highest number BUILD_ID.
(in my example it chooses -3.xpak instead of -4.xpak).
2 - just doing a FS directory walk to find any .xpak's that way, instead of using the Packages cache file is not implemented.
3 - Also broken is binhost fetch -f or -F download support from a multi-instance target - Bug #654608 - but that is substantially more problematic.

I have also added some extra Q_ metadata variables that were as yet unaccounted for, that we can cache from the Packages index file format. Just because it took me several days to understand why PATH was not being read, how to even do so, and having other variables already exist and set up could save a new contributor some time, and since the ABI of "libq" was affected by adding PATH anyway.

- Thank you. I Will be available on gentoo IRC as genr8\<tabcomplete\> to discuss, and I think I can be of use working on this important tool.