### PR TITLE
Libtool removal

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,7 +78,7 @@ q_CPPFLAGS = \
 	$(LIBZ_CFLAGS) \
 	$(NULL)
 q_LDADD = \
-	$(top_builddir)/libq/libq.la \
+	$(top_builddir)/libq/libq.a \
 	$(top_builddir)/autotools/gnulib/libgnu.a \
 	$(OPENMP_CFLAGS) \
 	$(LIBSSL_LIBS) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -73,14 +73,17 @@ q_CPPFLAGS = \
 	-I$(top_builddir)/autotools/gnulib \
 	-I$(top_srcdir)/autotools/gnulib \
 	$(OPENMP_CFLAGS) \
+	$(LIBSSL_CFLAGS) \
+	$(LIBBL2_CFLAGS) \
+	$(LIBZ_CFLAGS) \
 	$(NULL)
 q_LDADD = \
 	$(top_builddir)/libq/libq.la \
 	$(top_builddir)/autotools/gnulib/libgnu.a \
 	$(OPENMP_CFLAGS) \
-	$(LIBSSL) \
-	$(LIBBL2) \
-	$(LIBZ) \
+	$(LIBSSL_LIBS) \
+	$(LIBBL2_LIBS) \
+	$(LIBZ_LIBS) \
 	$(GPGME_LIBS) \
 	$(LIB_CLOCK_GETTIME) \
 	$(LIB_EACCESS) \

--- a/configure.ac
+++ b/configure.ac
@@ -52,104 +52,71 @@ AC_DEFINE_UNQUOTED([CONFIG_EPREFIX], ["$with_eprefix"],
 AC_SUBST([CONFIG_EPREFIX], ["$with_eprefix"])
 
 AC_ARG_ENABLE([qmanifest], [AS_HELP_STRING([--enable-qmanifest],
-			  [support qmanifest applet])],
-			  [], [enable_qmanifest=auto])
+			  [support qmanifest applet])])
 AC_ARG_ENABLE([qtegrity], [AS_HELP_STRING([--enable-qtegrity],
-			  [support qtegrity applet])],
-			  [], [enable_qtegrity=auto])
-LIBSSL=
-LIBBL2=
-LIBZ=
-HASGPGME=
+			  [support qtegrity applet])])
 
-AS_IF([test "x${enable_qmanifest}x${enable_qtegrity}" != xnoxno],
-	  [AC_CHECK_HEADERS([openssl/err.h \
-	                     openssl/ssl.h], [], [LIBSSL=_missing_header])
-	   AC_CHECK_LIB([ssl${LIBSSL}], [SSL_connect],
-					[LIBSSL="-lssl"
-					 AC_DEFINE([HAVE_SSL], [1], [Define if you have ssl])
-					 AC_CHECK_LIB([crypto],
-								  [ERR_reason_error_string],
-								  [LIBSSL="${LIBSSL} -lcrypto"],
-								  [])
-					 AC_SUBST([LIBSSL], ["${LIBSSL}"])
-					],
-					[if test "x$enable_qmanifest" != xauto; then
-					 AC_MSG_FAILURE(
-					   [--enable-qmanifest was given, but test for ssl failed])
-					 fi
-					 if test "x$enable_qtegrity" != xauto; then
-					 AC_MSG_FAILURE(
-					   [--enable-qtegrity was given, but test for ssl failed])
-					 fi
-					 LIBSSL=
-					])
-	   AC_MSG_CHECKING([whether to enable qtegrity])
-	   case "x${LIBSSL}" in
-		   "x-lssl"*)
-				AC_MSG_RESULT([yes])
-				;;
-		   *)
-			   enable_qtegrity=no
-			   AC_MSG_RESULT([no: missing dependencies])
-			   ;;
-	   esac
-	   if test "x$enable_qtegrity" != xno ; then
-		   AC_DEFINE([ENABLE_QTEGRITY], [1],
-					 [Define if qtegrity should be compiled])
-	   fi
-	],
-	[
-	   AC_MSG_CHECKING([whether to enable qtegrity])
-	   AC_MSG_RESULT([no: disabled by configure argument])
-	])
-AS_IF([test "x$enable_qmanifest" != xno],
-	  [AC_CHECK_HEADERS([blake2.h], [], [LIBBL2=_missing_header])
-	   AC_CHECK_LIB([b2${LIBBL2}], [blake2b_update],
-					[LIBBL2="-lb2"
-					 AC_DEFINE([HAVE_BLAKE2B], [1],
-							   [Define if you have blake2b])
-					 AC_SUBST([LIBBL2], ["${LIBBL2}"])
-					],
-					[if test "x$enable_qmanifest" != xauto; then
-					 AC_MSG_FAILURE(
-					   [--enable-qmanifest was given, but test for blake2b failed])
-					 fi
-					 LIBBL2=
-					])
-	   AC_CHECK_HEADERS([zlib.h], [], [LIBZ=_missing_header])
-	   AC_CHECK_LIB([z${LIBZ}], [gzopen],
-					[LIBZ="-lz"
-					 AC_DEFINE([HAVE_LIBZ], [1],
-							   [Define if you have zlib])
-					 AC_SUBST([LIBZ], ["${LIBZ}"])
-					],
-					[if test "x$enable_qmanifest" != xauto; then
-					 AC_MSG_FAILURE(
-					   [--enable-qmanifest was given, but test for libz failed])
-					 fi
-					 LIBZ=
-					])
-	   AM_PATH_GPGME([], [HASGPGME=yes])
-	   AC_MSG_CHECKING([whether to enable qmanifest])
-	   case "x${LIBSSL}${LIBBL2}${LIBZ}-${HASGPGME}" in
-		   "x-lssl"*"-lb2-lz-yes")
-				AC_MSG_RESULT([yes])
-				;;
-		   *)
-			   enable_qmanifest=no
-			   AC_MSG_RESULT([no: missing dependencies])
-			   ;;
-	   esac
-	   if test "x$enable_qmanifest" != xno ; then
-		   AC_DEFINE([ENABLE_QMANIFEST], [1],
-					 [Define if qmanifest should be compiled])
-	   fi
-	],
-	[
-	   AC_MSG_CHECKING([whether to enable qmanifest])
-	   AC_MSG_RESULT([no: disabled by configure argument])
-	])
+AS_IF([test "x${enable_qmanifest}${enable_qtegrity}" != "xnono"], [
+  PKG_CHECK_MODULES([LIBSSL], [libcrypto], [
+    AC_DEFINE([HAVE_SSL], [1], [Define if you have ssl])
+    LIBSSL="yes"
+  ], [
+    AS_IF([test "x${enable_qmanifest}" = "xyes"], [
+      AC_MSG_FAILURE([--enable-qmanifest was given, but libcrypto.pc could not be found])
+    ])
+    AS_IF([test "x${enable_qtegrity}" = "xyes"], [
+      AC_MSG_FAILURE([--enable-qtegrity was given, but libcrypto.pc could not be found])
+    ])
+    LIBSSL="no: missing dependencies"
+  ])
+  AC_MSG_CHECKING([whether to enable qtegrity])
+  AC_MSG_RESULT([${LIBSSL}])
+], [
+  AC_MSG_CHECKING([whether to enable qtegrity])
+  AC_MSG_RESULT([no: disabled by configure argument])
+])
+
+AS_IF([test "x${enable_qmanifest}" != "xno"], [
+  PKG_CHECK_MODULES([LIBBL2], [libb2], [
+    AC_DEFINE([HAVE_BLAKE2B], [1], [Define if you have blake2b])
+    LIBBL2="yes"
+  ], [
+    AS_IF([test "x${enable_qmanifest}" = "xyes"], [
+      AC_MSG_FAILURE([--enable-qmanifest was given, but libb2.pc could not be found])
+    ])
+    LIBBL2="no: missing dependencies"
+  ])
+
+  PKG_CHECK_MODULES([LIBZ], [zlib], [
+    AC_DEFINE([HAVE_LIBZ], [1], [Define if you have zlib])
+    LIBZ="yes"
+  ], [
+    AS_IF([test "x${enable_qmanifest}" = "xyes"], [
+      AC_MSG_FAILURE([--enable-qmanifest was given, but zlib.pc could not be found])
+    ])
+    LIBZ="no: missing dependencies"
+  ])
+
+  PKG_CHECK_MODULES([GPGME], [gpgme], [
+    GPGME="yes"
+  ], [
+    AS_IF([test "x${enable_qmanifest}" = "xyes"], [
+      AC_MSG_FAILURE([--enable-qmanifest was given, but gpgme.pc could not be found])
+    ])
+    GPGME="no: missing dependencies"
+  ])
+
+  AC_MSG_CHECKING([whether to enable qmanifest])
+  AS_IF([test "x${LIBBL2}${LIBZ}${GPGME}" = "xyesyesyes"], [
+    AC_MSG_RESULT([yes])
+  ], [
+    AC_MSG_RESULT([no: missing dependencies])
+  ])
+], [
+  AC_MSG_CHECKING([whether to enable qmanifest])
+  AC_MSG_RESULT([no: disabled by configure argument])
+])
+
 AM_CONDITIONAL([QMANIFEST_ENABLED], [test "x$enable_qmanifest" != xno])
 AM_CONDITIONAL([QTEGRITY_ENABLED], [test "x$enable_qtegrity" != xno])
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 
 AC_PREREQ([2.71])
 AC_INIT([portage-utils],[git])
-AM_INIT_AUTOMAKE([1.11 dist-xz no-dist-gzip silent-rules -Wall])
+AM_INIT_AUTOMAKE([1.11 dist-xz foreign no-dist-gzip silent-rules -Wall])
 AM_SILENT_RULES([yes]) # AM_INIT_AUTOMAKE([silent-rules]) is broken atm
 AM_MAINTAINER_MODE([enable])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -21,8 +21,7 @@ gl_EARLY
 gl_INIT
 
 AM_PROG_AR
-LT_INIT
-AC_SUBST([LIBTOOL_DEPS])
+AC_PROG_LN_S
 
 headers='#ifdef HAVE_STDDEF_H
 #include <stddef.h>

--- a/libq/Makefile.am
+++ b/libq/Makefile.am
@@ -34,9 +34,9 @@ QFILES += hash_md5_sha1.c hash_md5_sha1.h
 endif
 endif
 
-noinst_LTLIBRARIES = libq.la
-libq_la_SOURCES = $(QFILES)
-libq_la_CPPFLAGS = \
+noinst_LIBRARIES = libq.a
+libq_a_SOURCES = $(QFILES)
+libq_a_CPPFLAGS = \
 	$(OPENMP_CFLAGS) \
 	-I$(top_builddir)/autotools/gnulib \
 	-I$(top_srcdir)/autotools/gnulib

--- a/tests/atom_explode/Makefile.am
+++ b/tests/atom_explode/Makefile.am
@@ -7,7 +7,7 @@ e_CPPFLAGS = -I$(top_srcdir) \
 			 -I$(top_srcdir)/libq \
 			 -I$(top_builddir)/autotools/gnulib \
 			 -I$(top_srcdir)/autotools/gnulib
-e_LDADD = $(top_builddir)/libq/libq.la \
+e_LDADD = $(top_builddir)/libq/libq.a \
 		  $(top_builddir)/autotools/gnulib/libgnu.a \
 		  $(LIB_CLOCK_GETTIME) \
 		  $(LIB_EACCESS)

--- a/tests/copy_file/Makefile.am
+++ b/tests/copy_file/Makefile.am
@@ -7,7 +7,7 @@ m_CPPFLAGS = -I$(top_srcdir) \
 			 -I$(top_srcdir)/libq \
 			 -I$(top_builddir)/autotools/gnulib \
 			 -I$(top_srcdir)/autotools/gnulib
-m_LDADD = $(top_builddir)/libq/libq.la \
+m_LDADD = $(top_builddir)/libq/libq.a \
 		  $(top_builddir)/autotools/gnulib/libgnu.a \
 		  $(LIB_CLOCK_GETTIME) \
 		  $(LIB_EACCESS) \

--- a/tests/mkdir/Makefile.am
+++ b/tests/mkdir/Makefile.am
@@ -7,7 +7,7 @@ m_CPPFLAGS = -I$(top_srcdir) \
 			 -I$(top_srcdir)/libq \
 			 -I$(top_builddir)/autotools/gnulib \
 			 -I$(top_srcdir)/autotools/gnulib
-m_LDADD = $(top_builddir)/libq/libq.la \
+m_LDADD = $(top_builddir)/libq/libq.a \
 		  $(top_builddir)/autotools/gnulib/libgnu.a \
 		  $(LIB_CLOCK_GETTIME) \
 		  $(LIB_EACCESS)

--- a/tests/rmspace/Makefile.am
+++ b/tests/rmspace/Makefile.am
@@ -7,7 +7,7 @@ m_CPPFLAGS = -I$(top_srcdir) \
 			 -I$(top_srcdir)/libq \
 			 -I$(top_builddir)/autotools/gnulib \
 			 -I$(top_srcdir)/autotools/gnulib
-m_LDADD = $(top_builddir)/libq/libq.la \
+m_LDADD = $(top_builddir)/libq/libq.a \
 		  $(top_builddir)/autotools/gnulib/libgnu.a \
 		  $(LIB_CLOCK_GETTIME) \
 		  $(LIB_EACCESS)


### PR DESCRIPTION
With `./configure LDFLAGS="-static"` I now get

    $ ldd tmp/usr/local/bin/q
      not a dynamic executable