### PR TITLE
do not create .cfg file for config protected files which are not modified by the user. 

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -395,7 +395,7 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 DIST_SUBDIRS = $(SUBDIRS)
 am__DIST_COMMON = $(dist_man_MANS) $(srcdir)/Makefile.in \
-	$(srcdir)/config.h.in COPYING INSTALL README.md ar-lib compile \
+	$(srcdir)/config.h.in COPYING README.md ar-lib compile \
 	config.guess config.sub depcomp install-sh ltmain.sh missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)

--- a/libq/Makefile.am
+++ b/libq/Makefile.am
@@ -26,6 +26,7 @@ QFILES = \
 	xpak.c xpak.h \
 	xregex.c xregex.h \
 	xsystem.c xsystem.h \
+	cur_sys_pkg.c cur_sys_pkg.h \
 	$(NULL)
 
 if !QMANIFEST_ENABLED

--- a/libq/Makefile.in
+++ b/libq/Makefile.in
@@ -261,7 +261,8 @@ am__libq_a_SOURCES_DIST = atom.c atom.h basename.c basename.h \
 	rmspace.h safe_io.c safe_io.h scandirat.c scandirat.h set.c \
 	set.h tree.c tree.h xarray.c xarray.h xasprintf.h xchdir.c \
 	xchdir.h xmkdir.c xmkdir.h xpak.c xpak.h xregex.c xregex.h \
-	xsystem.c xsystem.h hash_md5_sha1.c hash_md5_sha1.h
+	xsystem.c xsystem.h cur_sys_pkg.c cur_sys_pkg.h \
+	hash_md5_sha1.c hash_md5_sha1.h
 @QMANIFEST_ENABLED_FALSE@@QTEGRITY_ENABLED_FALSE@am__objects_1 = libq_a-hash_md5_sha1.$(OBJEXT)
 am__objects_2 = libq_a-atom.$(OBJEXT) libq_a-basename.$(OBJEXT) \
 	libq_a-colors.$(OBJEXT) libq_a-contents.$(OBJEXT) \
@@ -274,7 +275,8 @@ am__objects_2 = libq_a-atom.$(OBJEXT) libq_a-basename.$(OBJEXT) \
 	libq_a-tree.$(OBJEXT) libq_a-xarray.$(OBJEXT) \
 	libq_a-xchdir.$(OBJEXT) libq_a-xmkdir.$(OBJEXT) \
 	libq_a-xpak.$(OBJEXT) libq_a-xregex.$(OBJEXT) \
-	libq_a-xsystem.$(OBJEXT) $(am__objects_1)
+	libq_a-xsystem.$(OBJEXT) libq_a-cur_sys_pkg.$(OBJEXT) \
+	$(am__objects_1)
 am_libq_a_OBJECTS = $(am__objects_2)
 libq_a_OBJECTS = $(am_libq_a_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -295,8 +297,9 @@ am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ./$(DEPDIR)/libq_a-atom.Po \
 	./$(DEPDIR)/libq_a-basename.Po ./$(DEPDIR)/libq_a-colors.Po \
 	./$(DEPDIR)/libq_a-contents.Po ./$(DEPDIR)/libq_a-copy_file.Po \
-	./$(DEPDIR)/libq_a-dep.Po ./$(DEPDIR)/libq_a-eat_file.Po \
-	./$(DEPDIR)/libq_a-hash.Po ./$(DEPDIR)/libq_a-hash_md5_sha1.Po \
+	./$(DEPDIR)/libq_a-cur_sys_pkg.Po ./$(DEPDIR)/libq_a-dep.Po \
+	./$(DEPDIR)/libq_a-eat_file.Po ./$(DEPDIR)/libq_a-hash.Po \
+	./$(DEPDIR)/libq_a-hash_md5_sha1.Po \
 	./$(DEPDIR)/libq_a-human_readable.Po \
 	./$(DEPDIR)/libq_a-move_file.Po ./$(DEPDIR)/libq_a-prelink.Po \
 	./$(DEPDIR)/libq_a-profile.Po ./$(DEPDIR)/libq_a-rmspace.Po \
@@ -1610,7 +1613,7 @@ QFILES = atom.c atom.h basename.c basename.h busybox.h colors.c \
 	safe_io.h scandirat.c scandirat.h set.c set.h tree.c tree.h \
 	xarray.c xarray.h xasprintf.h xchdir.c xchdir.h xmkdir.c \
 	xmkdir.h xpak.c xpak.h xregex.c xregex.h xsystem.c xsystem.h \
-	$(NULL) $(am__append_1)
+	cur_sys_pkg.c cur_sys_pkg.h $(NULL) $(am__append_1)
 noinst_LIBRARIES = libq.a
 libq_a_SOURCES = $(QFILES)
 libq_a_CPPFLAGS = \
@@ -1671,6 +1674,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libq_a-colors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libq_a-contents.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libq_a-copy_file.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libq_a-cur_sys_pkg.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libq_a-dep.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libq_a-eat_file.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libq_a-hash.Po@am__quote@ # am--include-marker
@@ -2033,6 +2037,20 @@ libq_a-xsystem.obj: xsystem.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libq_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libq_a-xsystem.obj `if test -f 'xsystem.c'; then $(CYGPATH_W) 'xsystem.c'; else $(CYGPATH_W) '$(srcdir)/xsystem.c'; fi`
 
+libq_a-cur_sys_pkg.o: cur_sys_pkg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libq_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libq_a-cur_sys_pkg.o -MD -MP -MF $(DEPDIR)/libq_a-cur_sys_pkg.Tpo -c -o libq_a-cur_sys_pkg.o `test -f 'cur_sys_pkg.c' || echo '$(srcdir)/'`cur_sys_pkg.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libq_a-cur_sys_pkg.Tpo $(DEPDIR)/libq_a-cur_sys_pkg.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='cur_sys_pkg.c' object='libq_a-cur_sys_pkg.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libq_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libq_a-cur_sys_pkg.o `test -f 'cur_sys_pkg.c' || echo '$(srcdir)/'`cur_sys_pkg.c
+
+libq_a-cur_sys_pkg.obj: cur_sys_pkg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libq_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libq_a-cur_sys_pkg.obj -MD -MP -MF $(DEPDIR)/libq_a-cur_sys_pkg.Tpo -c -o libq_a-cur_sys_pkg.obj `if test -f 'cur_sys_pkg.c'; then $(CYGPATH_W) 'cur_sys_pkg.c'; else $(CYGPATH_W) '$(srcdir)/cur_sys_pkg.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libq_a-cur_sys_pkg.Tpo $(DEPDIR)/libq_a-cur_sys_pkg.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='cur_sys_pkg.c' object='libq_a-cur_sys_pkg.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libq_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libq_a-cur_sys_pkg.obj `if test -f 'cur_sys_pkg.c'; then $(CYGPATH_W) 'cur_sys_pkg.c'; else $(CYGPATH_W) '$(srcdir)/cur_sys_pkg.c'; fi`
+
 libq_a-hash_md5_sha1.o: hash_md5_sha1.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libq_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libq_a-hash_md5_sha1.o -MD -MP -MF $(DEPDIR)/libq_a-hash_md5_sha1.Tpo -c -o libq_a-hash_md5_sha1.o `test -f 'hash_md5_sha1.c' || echo '$(srcdir)/'`hash_md5_sha1.c
 @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libq_a-hash_md5_sha1.Tpo $(DEPDIR)/libq_a-hash_md5_sha1.Po
@@ -2175,6 +2193,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/libq_a-colors.Po
 	-rm -f ./$(DEPDIR)/libq_a-contents.Po
 	-rm -f ./$(DEPDIR)/libq_a-copy_file.Po
+	-rm -f ./$(DEPDIR)/libq_a-cur_sys_pkg.Po
 	-rm -f ./$(DEPDIR)/libq_a-dep.Po
 	-rm -f ./$(DEPDIR)/libq_a-eat_file.Po
 	-rm -f ./$(DEPDIR)/libq_a-hash.Po
@@ -2244,6 +2263,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/libq_a-colors.Po
 	-rm -f ./$(DEPDIR)/libq_a-contents.Po
 	-rm -f ./$(DEPDIR)/libq_a-copy_file.Po
+	-rm -f ./$(DEPDIR)/libq_a-cur_sys_pkg.Po
 	-rm -f ./$(DEPDIR)/libq_a-dep.Po
 	-rm -f ./$(DEPDIR)/libq_a-eat_file.Po
 	-rm -f ./$(DEPDIR)/libq_a-hash.Po

--- a/libq/contents.c
+++ b/libq/contents.c
@@ -15,6 +15,59 @@
 
 #include "contents.h"
 
+//private
+
+int parser(contents_entry *e,char *line,char *end_line)
+{
+  e->_data=line;
+
+  if (!strncmp(e->_data, "obj ", 4))
+		e->type = CONTENTS_OBJ;
+	else if (!strncmp(e->_data, "dir ", 4))
+		e->type = CONTENTS_DIR;
+	else if (!strncmp(e->_data, "sym ", 4))
+		e->type = CONTENTS_SYM;
+	else
+		return -1;
+
+	e->name = e->_data + 4;
+
+  if(e->type == CONTENTS_DIR){
+    return 0;
+  }
+
+	/* obj /bin/bash 62ed51c8b23866777552643ec57614b0 1120707577 */
+	/* sym /bin/sh -> bash 1120707577 */
+
+  //timestamp
+  for (;*end_line!=' ';--end_line) {}
+
+  if(end_line == e->name){
+    return -9;
+  }
+  e->mtime_str=end_line+1;
+	e->mtime = strtol(e->mtime_str, NULL, 10);
+	if (e->mtime == LONG_MAX) {
+    e->mtime = 0;
+    e->mtime_str = NULL;
+  }
+  *end_line='\0';
+
+  //hash
+  if(e->type == CONTENTS_OBJ){
+    for (;*end_line!=' ';--end_line) {} 
+    if(end_line == e->name){
+        return -9;
+    }
+    e->digest=end_line+1;
+    *end_line='\0';
+  }
+  
+  //name is already set
+  return 0;
+}
+
+//public 
 /*
  * Parse a line of CONTENTS file and provide access to the individual fields
  */
@@ -33,53 +86,35 @@ contents_parse_line(char *line)
 		*p = '\0';
 
 	memset(&e, 0x00, sizeof(e));
-	e._data = line;
 
-	if (!strncmp(e._data, "obj ", 4))
-		e.type = CONTENTS_OBJ;
-	else if (!strncmp(e._data, "dir ", 4))
-		e.type = CONTENTS_DIR;
-	else if (!strncmp(e._data, "sym ", 4))
-		e.type = CONTENTS_SYM;
-	else
-		return NULL;
+  if(parser(&e,line,p-1)){
+    return NULL;
+  }
+  return &e;
+}
+/*
+ * Parse a line of CONTENTS file and provide access to the individual fields
+ * updating an exsiting contents_entry if possible, otherwise creating a new one
+ * It's possible to give the length of the line, if you don't know pass -1 e the function
+ * will compute themself
+ */
 
-	e.name = e._data + 4;
+int update_entry_contents_parse_line(contents_entry *entry,char *line,int line_len)
+{
+  char *p;
+  if(line_len <= 0){
+    line_len = strlen(line);
+  }
+	if (line == NULL || *line == '\0' || *line == '\n')
+		return -1;
+  
+  if(entry==NULL){
+    memset(entry,0x00,sizeof(*entry));
+  }
 
-	switch (e.type) {
-		/* dir /bin */
-		case CONTENTS_DIR:
-			break;
-
-		/* obj /bin/bash 62ed51c8b23866777552643ec57614b0 1120707577 */
-		case CONTENTS_OBJ:
-			if ((e.mtime_str = strrchr(e.name, ' ')) == NULL)
-				return NULL;
-			*e.mtime_str++ = '\0';
-			if ((e.digest = strrchr(e.name, ' ')) == NULL)
-				return NULL;
-			*e.digest++ = '\0';
-			break;
-
-		/* sym /bin/sh -> bash 1120707577 */
-		case CONTENTS_SYM:
-			if ((e.mtime_str = strrchr(e.name, ' ')) == NULL)
-				return NULL;
-			*e.mtime_str++ = '\0';
-			if ((e.sym_target = strstr(e.name, " -> ")) == NULL)
-				return NULL;
-			*e.sym_target = '\0';
-			e.sym_target += 4;
-			break;
-	}
-
-	if (e.mtime_str) {
-		e.mtime = strtol(e.mtime_str, NULL, 10);
-		if (e.mtime == LONG_MAX) {
-			e.mtime = 0;
-			e.mtime_str = NULL;
-		}
-	}
-
-	return &e;
+	/* chop trailing newline */
+	p = &line[line_len - 1];
+	if (*p == '\n')
+		*p = '\0';
+  return parser(entry,line,p-1);
 }

--- a/libq/contents.c
+++ b/libq/contents.c
@@ -15,106 +15,73 @@
 
 #include "contents.h"
 
-//private
 
-int parser(contents_entry *e,char *line,char *end_line)
+
+/*
+ * Parse a line of CONTENTS file and provide access to the individual fields
+ */
+contents_entry *
+contents_parse_line_general(char *line,int line_len)
 {
-  e->_data=line;
+	static contents_entry e;
+	char *p;
 
-  if (!strncmp(e->_data, "obj ", 4))
-		e->type = CONTENTS_OBJ;
-	else if (!strncmp(e->_data, "dir ", 4))
-		e->type = CONTENTS_DIR;
-	else if (!strncmp(e->_data, "sym ", 4))
-		e->type = CONTENTS_SYM;
+  if(line_len <= 0)
+  {
+    line_len = strlen(line);
+  }
+
+	if (line == NULL || *line == '\0' || *line == '\n')
+		return NULL;
+
+	/* chop trailing newline */
+	p = &line[line_len - 1];
+	if (*p == '\n')
+		*p = '\0';
+
+	memset(&e, 0x00, sizeof(e));
+  e._data=line;
+
+  if (!strncmp(e._data, "obj ", 4))
+		e.type = CONTENTS_OBJ;
+	else if (!strncmp(e._data, "dir ", 4))
+		e.type = CONTENTS_DIR;
+	else if (!strncmp(e._data, "sym ", 4))
+		e.type = CONTENTS_SYM;
 	else
-		return -1;
+		return NULL;
 
-	e->name = e->_data + 4;
+	e.name = e._data + 4;
 
-  if(e->type == CONTENTS_DIR){
-    return 0;
+  if(e.type == CONTENTS_DIR){
+    return NULL;
   }
 
 	/* obj /bin/bash 62ed51c8b23866777552643ec57614b0 1120707577 */
 	/* sym /bin/sh -> bash 1120707577 */
 
   //timestamp
-  for (;*end_line!=' ';--end_line) {}
+  for (;*p!=' ';--p) {}
 
-  if(end_line == e->name){
-    return -9;
-  }
-  e->mtime_str=end_line+1;
-	e->mtime = strtol(e->mtime_str, NULL, 10);
-	if (e->mtime == LONG_MAX) {
-    e->mtime = 0;
-    e->mtime_str = NULL;
-  }
-  *end_line='\0';
-
-  //hash
-  if(e->type == CONTENTS_OBJ){
-    for (;*end_line!=' ';--end_line) {} 
-    if(end_line == e->name){
-        return -9;
-    }
-    e->digest=end_line+1;
-    *end_line='\0';
-  }
-  
-  //name is already set
-  return 0;
-}
-
-//public 
-/*
- * Parse a line of CONTENTS file and provide access to the individual fields
- */
-contents_entry *
-contents_parse_line(char *line)
-{
-	static contents_entry e;
-	char *p;
-
-	if (line == NULL || *line == '\0' || *line == '\n')
-		return NULL;
-
-	/* chop trailing newline */
-	p = &line[strlen(line) - 1];
-	if (*p == '\n')
-		*p = '\0';
-
-	memset(&e, 0x00, sizeof(e));
-
-  if(parser(&e,line,p-1)){
+  if(p == e.name){
     return NULL;
   }
+  e.mtime_str=p+1;
+	e.mtime = strtol(e.mtime_str, NULL, 10);
+	if (e.mtime == LONG_MAX) {
+    e.mtime = 0;
+    e.mtime_str = NULL;
+  }
+  *p='\0';
+
+  //hash
+  if(e.type == CONTENTS_OBJ){
+    for (;*p!=' ';--p) {} 
+    if(p == e.name){
+        return NULL;
+    }
+    e.digest=p+1;
+    *p='\0';
+  }
   return &e;
-}
-/*
- * Parse a line of CONTENTS file and provide access to the individual fields
- * updating an exsiting contents_entry if possible, otherwise creating a new one
- * It's possible to give the length of the line, if you don't know pass -1 e the function
- * will compute itself 
- */
-
-int update_entry_contents_parse_line(contents_entry *entry,char *line,int line_len)
-{
-  char *p;
-  if(line_len <= 0){
-    line_len = strlen(line);
-  }
-	if (line == NULL || *line == '\0' || *line == '\n')
-		return -1;
-  
-  if(entry==NULL){
-    memset(entry,0x00,sizeof(*entry));
-  }
-
-	/* chop trailing newline */
-	p = &line[line_len - 1];
-	if (*p == '\n')
-		*p = '\0';
-  return parser(entry,line,p-1);
 }

--- a/libq/contents.c
+++ b/libq/contents.c
@@ -96,7 +96,7 @@ contents_parse_line(char *line)
  * Parse a line of CONTENTS file and provide access to the individual fields
  * updating an exsiting contents_entry if possible, otherwise creating a new one
  * It's possible to give the length of the line, if you don't know pass -1 e the function
- * will compute themself
+ * will compute itself 
  */
 
 int update_entry_contents_parse_line(contents_entry *entry,char *line,int line_len)

--- a/libq/contents.h
+++ b/libq/contents.h
@@ -25,5 +25,6 @@ typedef struct {
 } contents_entry;
 
 contents_entry *contents_parse_line(char *line);
+int update_entry_contents_parse_line(contents_entry *entry,char *line, int line_len);
 
 #endif

--- a/libq/contents.h
+++ b/libq/contents.h
@@ -24,7 +24,7 @@ typedef struct {
 	long mtime;
 } contents_entry;
 
-contents_entry *contents_parse_line(char *line);
-int update_entry_contents_parse_line(contents_entry *entry,char *line, int line_len);
+#define contents_parse_line(l) contents_parse_line_general(l,-1);
+contents_entry *contents_parse_line_general(char *line,int line_len);
 
 #endif

--- a/libq/cur_sys_pkg.c
+++ b/libq/cur_sys_pkg.c
@@ -186,9 +186,7 @@ static int find_in_tree(cur_pkg_tree_node *root,char * key,char *hash,const char
   
     switch (is_greater) {
       case 0:
-        if(!strcmp(category,root->package_name)){
-          return !strcmp(hash,root->hash_buffer);
-        }
+        return !strcmp(category,root->hash_buffer && !strcmp(hash,root->package_name);
         break;
       case 1:
         return find_in_tree(root->greater,key,hash,category);

--- a/libq/cur_sys_pkg.c
+++ b/libq/cur_sys_pkg.c
@@ -82,6 +82,7 @@ static char *get_fullname_package(depend_atom *datom)
 
   return package_name;
 }
+
 static void add_node(cur_pkg_tree_node **root,char *data,char *key,
                      char *package_name,unsigned int safe_to_free)
 {
@@ -99,11 +100,12 @@ static void add_node(cur_pkg_tree_node **root,char *data,char *key,
 
   int is_greater=compare_hash_num((*root)->key,key);
   
+  if(!is_greater){
+    printf("there are two packages wich update the same file %s %s, the hash of the file is %s\n"
+            ,package_name,(*root)->package_name,data);
+  }
+
   switch (is_greater) {
-    case 0:
-          printf("there are two packages wich update the same file %s %s, the hash of the file is %s\n"
-                 ,package_name,(*root)->package_name,data);
-      return ;
     case 1:
       return add_node(&(*root)->greater,data,key,package_name,safe_to_free);
     case -1:
@@ -160,11 +162,8 @@ static void read_file_add_data(cur_pkg_tree_node **root,char *package_name)
     if(line_buffer[0]=='o' && line_buffer[1]=='b' && line_buffer[2]=='j')
     {
       char *key=NULL;
-      if(line_cont == NULL){
-        line_cont=contents_parse_line(line_buffer);
-      }else {
-        assert(!update_entry_contents_parse_line(line_cont,line_buffer,byte_read));
-      }
+      line_cont=contents_parse_line_general(line_buffer,byte_read);
+      assert(line_cont!=NULL);
       key=hash_from_string(line_cont->name,(size_t) ((line_cont->digest-1)- line_cont->name));
       add_node(root,strdup(line_cont->digest),key,package_name,safe_to_free);
       safe_to_free=0;
@@ -186,7 +185,7 @@ static int find_in_tree(cur_pkg_tree_node *root,char * key,char *hash,const char
   
     switch (is_greater) {
       case 0:
-        return !strcmp(category,root->hash_buffer && !strcmp(hash,root->package_name);
+        return !strcmp(hash,root->hash_buffer) && !strcmp(category,root->package_name);
         break;
       case 1:
         return find_in_tree(root->greater,key,hash,category);

--- a/libq/cur_sys_pkg.c
+++ b/libq/cur_sys_pkg.c
@@ -1,0 +1,348 @@
+#include "config.h"
+
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+#include <assert.h>
+#include <sys/stat.h> 
+#include <sys/types.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <xalloc.h>
+
+#include "atom.h"
+#include "hash.h"
+#include "xchdir.h"
+#include "cur_sys_pkg.h"
+
+
+#define HASH_SIZE 32
+#define SIZE_STR_VAR_DB_PKG 12
+
+//private
+
+//data
+typedef struct cur_pkg_tree_node {
+  char *key;
+  char *hash_buffer;
+  char *package_name;
+  unsigned int safe_to_free_package_name;
+  struct cur_pkg_tree_node *greater;
+  struct cur_pkg_tree_node *minor;
+}cur_pkg_tree_node;
+
+
+//functions
+static unsigned int conv_char_int(char dig)
+{
+  if((int) dig > 57) 
+  {
+    return (int)dig - 87;
+  }
+  return (int )dig - 48;
+}
+
+static int compare_hash_num(char *hash1,char*hash2)
+{
+  int temp1,temp2;
+  for(int i=0;i<HASH_SIZE;++i)
+  {
+    temp1=conv_char_int(hash1[i]);
+    temp2=conv_char_int(hash2[i]);
+    if(temp2 > temp1)
+    {
+      return 1;
+    }else if (temp2 < temp1) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+static char *get_fullname_package(depend_atom *datom)
+{
+  int cat_len,name_len=0;
+  char *package_name =NULL;
+
+  assert(datom!=NULL);
+  assert(datom->CATEGORY!=NULL);
+  assert(datom->PN!=NULL);
+
+  cat_len=strlen(datom->CATEGORY);
+  name_len=strlen(datom->PN);
+  package_name=calloc((cat_len +1+ name_len +1), sizeof(*package_name));
+  package_name[cat_len + 1 +name_len]='\0';
+
+  strcat(package_name,datom->CATEGORY);
+  strcat(package_name,"/");
+  strcat(package_name,datom->PN);
+
+  return package_name;
+}
+static void add_node(cur_pkg_tree_node **root,char *data,char *key,
+                     char *package_name,unsigned int safe_to_free)
+{
+  if(*root==NULL)
+  {
+    *root=xmalloc(sizeof(**root));
+    (*root)->key=key;
+    (*root)->hash_buffer=data;
+    (*root)->package_name=package_name;
+    (*root)->safe_to_free_package_name=safe_to_free;
+    (*root)->greater=NULL;
+    (*root)->minor=NULL;
+    return;
+  }
+
+  int is_greater=compare_hash_num((*root)->key,key);
+  
+  switch (is_greater) {
+    case 0:
+          printf("there are two packages wich update the same file %s %s, the hash of the file is %s\n"
+                 ,package_name,(*root)->package_name,data);
+      return ;
+    case 1:
+      return add_node(&(*root)->greater,data,key,package_name,safe_to_free);
+    case -1:
+      return add_node(&(*root)->minor,data,key,package_name,safe_to_free);
+  }
+}
+
+static char *hash_from_file(char *file_path_complete)
+{
+  FILE *file_to_hash;
+  char buf[512];
+  unsigned char hex_hash[HASH_SIZE+1];
+  hex_hash[HASH_SIZE]='\0';
+  MD5_CTX ctx;
+  
+  char *out = NULL;
+  out=xmalloc(HASH_SIZE+1* sizeof(*out));
+  out[HASH_SIZE]='\0';
+
+  file_to_hash = fopen(file_path_complete,"r");
+  if(file_to_hash == NULL)
+  {
+    fprintf(stderr, "%s not found\n",file_path_complete);
+    out=xmalloc(3* sizeof(*out));
+    out[0]='-';
+    out[1]='1';
+    out[2]='\0';
+
+    fclose(file_to_hash);
+
+    return out;
+  }
+  MD5_Init(&ctx);
+
+  size_t byte_read=0;
+  while ( ( byte_read = fread(buf,1,512,file_to_hash) ) > 0) {
+    MD5_Update(&ctx,buf,byte_read);
+  }
+  MD5_Final(hex_hash,&ctx);
+
+  hash_hex(out,hex_hash,(HASH_SIZE>>1));
+  out[HASH_SIZE]='\0';
+
+  fclose(file_to_hash);
+
+  return out;
+}
+
+char *hash_from_string(char *str,size_t len)
+{
+  unsigned char hex_buf[HASH_SIZE+1];
+  char *hash_final=xmalloc(HASH_SIZE+1*sizeof(*hash_final));
+  hash_final[HASH_SIZE]='\0';
+  hex_buf[HASH_SIZE]='\0';
+  MD5_CTX ctx;
+  
+  MD5_Init(&ctx);
+  MD5_Update(&ctx,str,len);
+  MD5_Final(hex_buf,&ctx);
+  hash_hex(hash_final,hex_buf,(HASH_SIZE>>1));
+  
+  return hash_final;
+}
+
+
+static int is_dir(char *string)
+{
+  struct stat path;
+  stat(string, &path);
+  return !S_ISREG(path.st_mode);
+}
+
+static void read_file_add_data(cur_pkg_tree_node **root,char *package_name)
+{
+  FILE *CONTENTS=fopen("./CONTENTS","r");
+  int byte_read = 0;
+  unsigned int safe_to_free = 1;
+  char *line_buffer=NULL;
+  char *line_buffer_end=NULL;
+  char *line_buffer_start_path=NULL;
+  char *hash_buffer=NULL;
+  char *key=NULL;
+  size_t line_buffer_size=0;
+  
+
+  //read file CONTENTS
+  while( (byte_read=getline(&line_buffer,&line_buffer_size,CONTENTS)) != -1 )
+  {
+    if(line_buffer[0]=='o' && line_buffer[1]=='b' && line_buffer[2]=='j')
+    {
+    	line_buffer_end=line_buffer+(byte_read-1);
+      while( !(60 < *line_buffer_end) && !(71> *line_buffer_end) )
+      {
+        *line_buffer_end='\0';
+        --line_buffer_end;
+      }
+      --line_buffer_end;
+
+      //timestamp
+      while(*line_buffer_end != ' ')
+      {
+        *line_buffer_end='\0';
+        --line_buffer_end;
+      }
+
+      //hash
+      *line_buffer_end = '\0';
+      line_buffer_end-=HASH_SIZE;
+      hash_buffer=strdup(line_buffer_end);
+      hash_buffer[HASH_SIZE] = '\0';
+  
+      //path
+      --line_buffer_end;
+      *line_buffer_end='\0';
+      line_buffer_start_path=line_buffer+4;
+      key=hash_from_string(line_buffer_start_path,line_buffer_end - line_buffer_start_path);
+
+      //tree
+      add_node(root,hash_buffer,key,package_name,safe_to_free);
+      safe_to_free=0;
+    }
+      key=NULL;
+      hash_buffer=NULL;
+      line_buffer_start_path=NULL;
+      line_buffer_end=NULL;
+  }
+
+  fclose(CONTENTS);
+  free(line_buffer);
+  hash_buffer=NULL;
+  line_buffer=NULL;
+  line_buffer_end=NULL;
+  line_buffer_start_path=NULL;
+}
+
+static int find_in_tree(cur_pkg_tree_node *root,char * key,char *hash,const char *category)
+{
+  if(!strcmp(hash,"-1")) return 1;
+
+  if(root != NULL)
+  { 
+    int is_greater=compare_hash_num(root->key,key);
+  
+    if(is_greater == 0 && !strcmp(category,root->package_name))
+      return !strcmp(hash,root->hash_buffer);
+
+    switch (is_greater) {
+      case 1:
+        return find_in_tree(root->greater,key,hash,category);
+        break;
+      case -1:
+        return find_in_tree(root->minor,key,hash,category);
+        break;
+      default:
+    }
+  }
+  return 0;
+}
+
+//public
+int create_cur_pkg_tree(const char *path, cur_pkg_tree_node **root, depend_atom *atom)
+{ 
+  char *package_name;
+  char *name_file;
+  DIR *dir = NULL;
+  struct dirent * dirent_struct = NULL;
+  int find_it =0;
+
+  xchdir(path);
+  dir=opendir(".");
+
+  while(!find_it && (dirent_struct=readdir(dir)) != NULL)
+  {
+    name_file=dirent_struct->d_name;
+    if(is_dir(name_file) && name_file[0] != '.' && 
+      (!strcmp(name_file,atom->CATEGORY) || strstr(name_file,atom->PN))){ 
+        //this case will possibly load also a wrong package 
+        //example car and car-lib but it should not be a problem 
+        create_cur_pkg_tree(name_file,root,atom);
+    }else if(!strcmp(name_file,"CONTENTS")){
+      package_name=get_fullname_package(atom);
+      read_file_add_data(root,package_name);
+      find_it=1;
+    }
+  }
+
+  closedir(dir);
+  xchdir("..");
+  return 0;
+}
+
+int is_default(cur_pkg_tree_node *root,char *file_path_complete,const char *category)
+{
+  char *key;
+  int res=0;
+  char *hash =NULL;
+
+  hash = hash_from_file(file_path_complete);
+  key= hash_from_string(file_path_complete,strlen(file_path_complete));
+  res = find_in_tree(root,key,hash,category);
+
+  free(hash);
+  free(key);
+  key=NULL;
+  hash=NULL;
+
+  return res;
+}
+
+void destroy_cur_pkg_tree(cur_pkg_tree_node *root)
+{
+  
+  if(root!=NULL)
+  {
+    destroy_cur_pkg_tree(root->greater);
+    destroy_cur_pkg_tree(root->minor);
+
+    free(root->hash_buffer);
+    root->hash_buffer=NULL;
+
+    free(root->key);
+    root->key=NULL;
+    
+    if(root->safe_to_free_package_name){
+      free(root->package_name);
+    }
+    root->package_name=NULL;
+
+    free(root);
+    root=NULL;
+  }
+}
+
+void in_order_visit(cur_pkg_tree_node *root)
+{
+  if(root!=NULL)
+  {
+    if(root->minor!=NULL) in_order_visit(root->minor);
+    printf("[%s,%s,%s,%s]\n",root->key,root->hash_buffer,
+           root->hash_buffer,root->package_name);
+    if(root->greater!=NULL) in_order_visit(root->greater);
+  }
+}

--- a/libq/cur_sys_pkg.h
+++ b/libq/cur_sys_pkg.h
@@ -1,0 +1,15 @@
+#ifndef CUR_SYS_PKG
+#define CUR_SYS_PKG
+
+//BST node with an entry for key(based on hash of filename) hash found in /var/db/pkg/.../CONTENTS, package fullname of the package
+typedef struct cur_pkg_tree_node cur_pkg_tree_node;
+
+void in_order_visit(cur_pkg_tree_node *root);
+//create the tree searching from the path with in
+int create_cur_pkg_tree(const char *path, cur_pkg_tree_node **root, depend_atom *atom);
+//return 1 if the file B of the package C is has the same hash of the one in /var/db/pkg/.../CONTENTS
+int is_default(cur_pkg_tree_node *root,char *file_path_complete,const char *category);
+//dealloc the tree
+void destroy_cur_pkg_tree(cur_pkg_tree_node *root);
+
+#endif // !CUR_SYS_PKG

--- a/qmerge.c
+++ b/qmerge.c
@@ -38,6 +38,9 @@
 #include "xpak.h"
 #include "xsystem.h"
 
+
+//patch
+
 #ifndef GLOB_BRACE
 # define GLOB_BRACE     (1 << 10)	/* Expand "{a,b}" to "a" "b".  */
 #endif


### PR DESCRIPTION
The Patch enable the qmerge to understand if a config protected file has the same hash of the entry in /var/db/pkg/[package_name]/CONTENTS. In this way if this is the case the qmerge overwrite without generating a .cfg file. The reason for that is pretty seample, the amount of .cfg file generated by qmerge is enormous in comparison with the emerge. This patch solves the problem. If a file in config protected is has a different hash from the entry in /var/db/pkg the .cfg will be generated. To do so my patch generate a tree with all the obj files of the packages the qmerge is currently installing. This process is made in the pkg_fetch funtion to also take the dependencies. Then in merge_tree_at function it checks if the hash of the file in the filesystem is in the tree, if it's not the .cfg will be generate otherwise this file will be managed as if it is not a config protected file at all. I also generalize the function in lib/contents.c in such a way that you can pass the length of the line. I still put a macro to preserve the compatibility with the old declaration. In the same function i also modify the implementation. In this way the function will also manage obj files which has space inside their name. I tried, where possible, to adapt my code to the standard of the project without reinventing anything if already present.  The patch does not add a notable performance overhead and i try to make it as efficient as possible. I  try to use the internal test of the repo but i could not understand what were they really test. All i can say is that, in the company where i work, we are using in production for the roll of the servers and everything is ok with the patch.