### PR TITLE
q_main: fix segfault

### DIFF
--- a/main.c
+++ b/main.c
@@ -839,7 +839,7 @@ read_one_repos_conf(const char *repos_conf, char **primary)
 		 * backwards to the front of the string */
 		do_trim = true;
 		e = NULL;
-		for (r = q = s - 2; q >= p; q--) {
+		for (r = q = s - 2; q >= p && s != 0; q--) {
 			if (do_trim && isspace((int)*q)) {
 				*q = '\0';
 				r = q - 1;

--- a/main.c
+++ b/main.c
@@ -839,7 +839,14 @@ read_one_repos_conf(const char *repos_conf, char **primary)
 		 * backwards to the front of the string */
 		do_trim = true;
 		e = NULL;
-		for (r = q = s - 2; q >= p && s != 0; q--) {
+
+		/* handle edge case where there is not a \n at the end */
+		if (s == 0) {
+		  p[strlen(p)] = '\n';
+		  s = p;
+		}
+
+		for (r = q = s - 2; q >= p; q--) {
 			if (do_trim && isspace((int)*q)) {
 				*q = '\0';
 				r = q - 1;


### PR DESCRIPTION
Fixed a potential segfault i ran into where if the last line of a config file within /etc/portage/repos.conf/ did not contain a newline character, q = s - 2 would evaluate to INT_MAX - 2, and be dereferenced resulting in a segfault