### PR TITLE
qlop: Properly handle atom_compar_cb when called from qsort

### DIFF
--- a/libq/atom.c
+++ b/libq/atom.c
@@ -1242,8 +1242,8 @@ atom_format(const char *format, const depend_atom *atom)
 inline int
 atom_compar_cb(const void *l, const void *r)
 {
-	const depend_atom *al = l;
-	const depend_atom *ar = r;
+	const depend_atom *al = *(const depend_atom**)l;
+	const depend_atom *ar = *(const depend_atom**)r;
 
 	switch (atom_compare(al, ar)) {
 		case EQUAL:  return  0;

--- a/libq/tree.c
+++ b/libq/tree.c
@@ -463,7 +463,7 @@ tree_pkg_compar(const void *l, const void *r)
 	depend_atom *al = tree_get_atom(pl, false);
 	depend_atom *ar = tree_get_atom(pr, false);
 
-	return atom_compar_cb(al, ar);
+	return atom_compar_cb(&al, &ar);
 }
 
 static tree_pkg_ctx *

--- a/qlop.c
+++ b/qlop.c
@@ -309,7 +309,7 @@ pkg_sort_cb(const void *l, const void *r)
 	depend_atom *al = pl->atom;
 	depend_atom *ar = pr->atom;
 
-	return atom_compar_cb(al, ar);
+	return atom_compar_cb(&al, &ar);
 }
 
 /* The format of the sync log has changed over time.


### PR DESCRIPTION
This pull request resolves an improper call to `qsort` when invoking `qlop -p`.
On current master it can lead to SEGFAULTs.

Detailed description is in the commit message.

Specific example of the SEGFAULT:

```
bstaletic@Gallifrey ~ % head -n 15 /var/lib/portage/world
app-admin/doas
app-admin/eclean-kernel
app-admin/sysklogd
app-alternatives/sh
app-arch/zip
app-editors/vim
app-eselect/eselect-python
app-eselect/eselect-repository
app-misc/asciinema
app-misc/jq
app-misc/tmux
app-portage/cpuid2cpuflags
app-portage/eix
app-portage/gentoolkit
app-portage/pfl
bstaletic@Gallifrey ~ % qlop -p `head -n 15 /var/lib/portage/world`
zsh: segmentation fault  qlop -p `head -n 15 /var/lib/portage/world`
```

It should be easier to hit the SEGFAULT with atoms that have versions. Or that might have been just my luck.

Not sure what the proper test would look like. Ideally, ASAN would be used in CI, but I see that #19 is still in progress.