### PR TITLE
qlop: Do not leak avgs array in predict mode

### DIFF
--- a/qlop.c
+++ b/qlop.c
@@ -1324,6 +1324,7 @@ static int do_emerge_log(
 				}
 			}
 		}
+		xarrayfree_int(avgs);
 	}
 
 	{

--- a/tests/atom_explode/test.c
+++ b/tests/atom_explode/test.c
@@ -64,6 +64,7 @@ int main(int argc, char *argv[])
 			boom(a, buf);
 			atom_implode(a);
 		}
+		free(buf);
 	}
 
 	return EXIT_SUCCESS;

--- a/tests/copy_file/test.c
+++ b/tests/copy_file/test.c
@@ -72,6 +72,7 @@ int main(int argc, char *argv[])
 	assert(buf != NULL);
 	memset(buf, 0xaf, len);
 	testone(buf, len);
+	free(buf);
 
 	return 0;
 }


### PR DESCRIPTION
Previously, `values_set(merge_averages, avgs)` would allocate `avgs`, then it would be used in `array_for_each(atoms, i, atom)`, but a call to `xarrayfree_int(avgs)` was missing after the loop.

Hopefully, this, along with #26, will solve the issues from #19.