### PR TITLE
More sanitizer-guided fixes

### DIFF
--- a/libq/xarray.c
+++ b/libq/xarray.c
@@ -46,7 +46,8 @@ void *xarraypush(array_t *arr, const void *ele, size_t ele_len)
 
 void xarraysort(array_t *arr, int (*compar)(const void *, const void *))
 {
-	qsort(arr->eles, arr->num, sizeof(void *), compar);
+	if (arr->num > 1)
+		qsort(arr->eles, arr->num, sizeof(void *), compar);
 }
 
 void xarraydelete_ptr(array_t *arr, size_t elem)


### PR DESCRIPTION
Commits go into more detail, but in short:

#### `rmspace/test.c`

Result check invoked UB for empty strings.

#### `qlop.c`

Calculating merge and unmerge averages when unmerges do not exist in the log passed `NULL` to `xarraysort()` and then `qsort()`.
That was caught by gcc ASAN. I have just guarded both `xarraysort()` calls in `qlop -a`. Maybe the check should be in `xarraysort()` itself?