### PR TITLE
qgrep: fix -Wcalloc-transposed-args warning

### DIFF
--- a/qgrep.c
+++ b/qgrep.c
@@ -555,7 +555,7 @@ int qgrep_main(int argc, char **argv)
 
 	if (argc > (optind + 1)) {
 		depend_atom **d = args.include_atoms =
-			xcalloc(sizeof(depend_atom *), (argc - optind - 1) + 1);
+			xcalloc((argc - optind - 1) + 1, sizeof(depend_atom *));
 		for (i = (optind + 1); i < argc; i++) {
 			*d = atom_explode(argv[i]);
 			if (*d == NULL) {


### PR DESCRIPTION
I get this warning when compiling portage-utils with `gcc (Gentoo 14.2.1_p20240817 p4) 14.2.1 20240817`.

    qgrep.c: In function ‘qgrep_main’:
    qgrep.c:558:40: warning: ‘xcalloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
      558 |                         xcalloc(sizeof(depend_atom *), (argc - optind - 1) + 1);
          |                                        ^~~~~~~~~~~
    qgrep.c:558:40: note: earlier argument should specify number of elements, later size of each element

