### PR TITLE
libq/atom: fix mixup of treating (-) as (+)

### DIFF
--- a/libq/atom.c
+++ b/libq/atom.c
@@ -254,7 +254,7 @@ atom_ctx *atom_explode_cat
           }
           else if (strncmp(ptr, "(-)", 3) == 0)
           {
-            w->sfx_cond = ATOM_UC_PREV_ENABLED;
+            w->sfx_cond = ATOM_UC_PREV_DISABLED;
             *ptr = '\0';
             ptr += 3;
           }


### PR DESCRIPTION
```
$ q --version
portage-utils-0.97.1
written for Gentoo by solar, vapier and grobian
```

Ebuild:
https://github.com/gentoo/gentoo/blob/master/virtual/blas/blas-3.8-r1.ebuild
```bash
# Copyright 1999-2026 Gentoo Authors
# Distributed under the terms of the GNU General Public License v2

EAPI="8"

DESCRIPTION="Virtual for FORTRAN 77 BLAS implementation"
SLOT="0"
KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ~ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
IUSE="eselect-ldso flexiblas index64"
REQUIRED_USE="?? ( eselect-ldso flexiblas )"

RDEPEND="
	flexiblas? (
		sci-libs/flexiblas[system-blas(-),index64(-)?]
		sci-libs/blas-lapack-aux-wrapper[index64?]
	)
	!flexiblas? (
		>=sci-libs/lapack-3.8[eselect-ldso(-)?,-flexiblas(-),index64(-)?]
		eselect-ldso? (
			|| (
				>=sci-libs/lapack-3.8[eselect-ldso(-)]
				sci-libs/openblas[eselect-ldso(-)]
				sci-libs/blis[eselect-ldso(-)]
			)
		)
	)
"
```

Before:
```
$ qdepends -vt virtual/blas
virtual/blas-3.8-r1:
RDEPEND="
    flexiblas? (
        sci-libs/flexiblas[system-blas(+),index64?]
        sci-libs/blas-lapack-aux-wrapper[index64?]
    )
    !flexiblas? (
        >=sci-libs/lapack-3.8[eselect-ldso?,-flexiblas(+),index64?]
        eselect-ldso? (
            || (
                >=sci-libs/lapack-3.8[eselect-ldso(+)]
                sci-libs/openblas[eselect-ldso(+)]
                sci-libs/blis[eselect-ldso(+)]
            )
        )
    )
"
```

After:
```
$ qdepends -vt virtual/blas
virtual/blas-3.8-r1:
RDEPEND="
    flexiblas? (
        sci-libs/flexiblas[system-blas(-),index64?]
        sci-libs/blas-lapack-aux-wrapper[index64?]
    )
    !flexiblas? (
        >=sci-libs/lapack-3.8[eselect-ldso?,-flexiblas(-),index64?]
        eselect-ldso? (
            || (
                >=sci-libs/lapack-3.8[eselect-ldso(-)]
                sci-libs/openblas[eselect-ldso(-)]
                sci-libs/blis[eselect-ldso(-)]
            )
        )
    )
"
```

Cherry-picking to 0.97 isn't clean as white space has changed a lot. I can make a pr for that. (Or you can apply from here https://github.com/parona-source/portage-utils/commit/441c35d27507a03d1a7038d45ebb27d25b984d6e)