### PR TITLE
quse.c: list each package only once (e.g. quse -e lz4)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,6 @@
 
 # quse
 - make -v only print requested USE-flag when flags given
-- list each package only once (e.g. quse -e lz4)
 
 # qkeyword
 - drop -c argument? it can be fully expressed using -p cat/

--- a/quse.c
+++ b/quse.c
@@ -70,6 +70,7 @@ struct quse_state {
 	const char *fmt;
 };
 
+static char *quse_last_atom_name = "";
 static char *_quse_getline_buf = NULL;
 static size_t _quse_getline_buflen = 0;
 #define GETLINE(FD, BUF, LEN) \
@@ -642,7 +643,11 @@ quse_results_cb(tree_pkg_ctx *pkg_ctx, void *priv)
 			free(us.retv);
 			free(us.argv);
 		} else {
-			printf("%s: %s\n", atom_format(state->fmt, atom), v);
+			/* we can skip consecutive duplicate atoms since they are already sorted */
+			if(strcmp(atom->PN, quse_last_atom_name) != 0) {
+				quse_last_atom_name = atom->PN;
+				printf("%s: %s\n", atom_format(state->fmt, atom), v);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Behavior before:
```
quse -e lz4
app-admin/eclean-kernel: lz4 lzo zstd test python_targets_python3_12 python_targets_python3_13 python_targets_python3_14
app-admin/eclean-kernel: lz4 lzo zstd test python_targets_python3_12 python_targets_python3_13 python_targets_python3_14
app-arch/libarchive: acl blake2 +bzip2 +e2fsprogs expat +iconv lz4 +lzma lzo nettle static-libs test xattr +zstd abi_x86_32 abi_x86_64 abi_x86_x32 abi_mips_n32 abi_mips_n64 abi_mips_o32 abi_s390_32 abi_s390_64 verify-sig
app-arch/sasquatch: debug deprecated lz4 lzma lzo xattr zstd
app-arch/sasquatch: debug deprecated lz4 lzma lzo xattr zstd
app-arch/zstd: +lzma lz4 static-libs test zlib abi_x86_32 abi_x86_64 abi_x86_x32 abi_mips_n32 abi_mips_n64 abi_mips_o32 abi_s390_32 abi_s390_64 verify-sig
app-arch/zstd: +lzma lz4 static-libs test zlib abi_x86_32 abi_x86_64 abi_x86_x32 abi_mips_n32 abi_mips_n64 abi_mips_o32 abi_s390_32 abi_s390_64
app-backup/dar: argon2 curl dar32 dar64 doc gcrypt gpg lz4 lzo nls rsync sftp whirlpool xattr
app-backup/dar: argon2 curl dar32 dar64 doc gcrypt gpg lz4 lzo nls rsync sftp whirlpool xattr
app-backup/fsarchiver: debug lz4 lzma lzo static +zstd
app-emulation/spice: gstreamer lz4 opus sasl smartcard static-libs test
app-emulation/spice: gstreamer lz4 opus sasl smartcard static-libs test
...
```

### Behavior after:
```
quse -e lz4
app-admin/eclean-kernel: lz4 lzo zstd test python_targets_python3_12 python_targets_python3_13 python_targets_python3_14
app-arch/libarchive: acl blake2 +bzip2 +e2fsprogs expat +iconv lz4 +lzma lzo nettle static-libs test xattr +zstd abi_x86_32 abi_x86_64 abi_x86_x32 abi_mips_n32 abi_mips_n64 abi_mips_o32 abi_s390_32 abi_s390_64 verify-sig
app-arch/sasquatch: debug deprecated lz4 lzma lzo xattr zstd
app-arch/zstd: +lzma lz4 static-libs test zlib abi_x86_32 abi_x86_64 abi_x86_x32 abi_mips_n32 abi_mips_n64 abi_mips_o32 abi_s390_32 abi_s390_64 verify-sig
app-backup/dar: argon2 curl dar32 dar64 doc gcrypt gpg lz4 lzo nls rsync sftp whirlpool xattr
app-backup/fsarchiver: debug lz4 lzma lzo static +zstd
app-emulation/spice: gstreamer lz4 opus sasl smartcard static-libs test
app-misc/carbon-c-relay: client lz4 snappy zlib ssl pcre2 +oniguruma
app-text/groonga: apache-arrow blosc curl debug json libedit lz4 +mecab msgpack stemmer suggest-learner xxhash zstd cpu_flags_x86_avx cpu_flags_x86_avx2 cpu_flags_x86_avx512dq
dev-db/postgresql: debug doc +icu kerberos ldap llvm +lz4 nls numa oauth pam perl python +readline selinux systemd ssl static-libs tcl test uring uuid xml zlib zstd +llvm_slot_21 llvm_slot_17 llvm_slot_18 llvm_slot_19 llvm_slot_20 python_single_target_python3_12 python_single_target_python3_13 python_single_target_python3_14
dev-libs/apache-arrow: +brotli bzip2 +compute +dataset +json lz4 +parquet +re2 +snappy ssl test zlib zstd
dev-libs/c-blosc: +lz4 +snappy test zlib zstd
dev-libs/dqlite: +lz4 test
dev-libs/librdkafka: +lz4 sasl ssl static-libs +zstd
dev-libs/raft: lz4 test zfs
dev-php/pecl-redis: igbinary +json lz4 +session zstd php_targets_php8-2 php_targets_php8-3 php_targets_php8-4 php_targets_php8-5
dev-util/squashdelta: lz4 +lzo
dev-util/squashmerge: lz4 +lzo
gui-apps/waypipe: dmabuf ffmpeg lz4 systemtap test vaapi zstd cpu_flags_x86_avx2 cpu_flags_x86_avx512f cpu_flags_x86_sse3 cpu_flags_arm_neon
mail-client/neomutt: autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet lmdb lz4 nls notmuch pgp-classic qdbm sasl selinux smime-classic ssl tokyocabinet test zlib zstd
net-analyzer/suricata: +af-packet bpf control-socket cuda debug +detection geoip hardened hyperscan lua lz4 nflog +nfqueue redis systemd test xdp lua_single_target_luajit lua_single_target_lua5-1 python_single_target_python3_12 python_single_target_python3_13 python_single_target_python3_14 verify-sig
net-analyzer/wireshark: androiddump bcg729 brotli +capinfos +captype ciscodump +dftest doc dpauxmon +dumpcap +editcap +gui http2 http3 ilbc kerberos lua lz4 maxminddb +mergecap +minizip +netlink opus pkcs11 +plugins +pcap +randpkt +randpktdump +reordercap sbc selinux +sharkd smi snappy spandsp sshdump ssl sdjournal test +text2pcap +tshark +udpdump wifi xxhash zlib +zstd +filecaps lua_single_target_lua5-3 lua_single_target_lua5-4
net-libs/czmq: curl drafts http-client http-server lz4 nss systemd test +uuid
net-libs/wandio: bzip2 http lzma lzo lz4 test zlib zstd
net-mail/dovecot: cdb kerberos ldap lua mysql pam postgres sqlite lz4 zstd solr stemmer textcat xapian argon2 managesieve selinux sieve static-libs suid systemd system-icu test unwind lua_single_target_lua5-3 lua_single_target_lua5-4 verify-sig
net-misc/rsync: acl examples iconv lz4 rrsync ssl stunnel system-zlib test xattr +xxhash zstd python_single_target_python3_12 python_single_target_python3_13 python_single_target_python3_14 python_single_target_python3_15
net-misc/rsync-bpc: acl lz4 xxhash
net-misc/spice-gtk: gtk-doc +gtk3 +introspection lz4 mjpeg policykit sasl smartcard usbredir vala valgrind wayland webdav
net-vpn/ocserv: geoip kerberos +lz4 +nftables otp pam radius +seccomp systemd tcpd root-tests test
net-vpn/openconnect: doc +gnutls gssapi libproxy lz4 nls pskc selinux smartcard stoken test
net-vpn/openvpn: dco down-root examples inotify iproute2 +lz4 +lzo mbedtls +openssl pam pkcs11 +plugins selinux systemd test
sci-libs/gdal: archive armadillo avif blosc cryptopp +curl cpu_flags_arm_neon cpu_flags_x86_avx cpu_flags_x86_avx2 cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse4_1 cpu_flags_x86_ssse3 exprtk fits geos gif gml hdf5 heif java jpeg2k jpegxl lerc libaec libdeflate lz4 lzma mongodb +muparser mysql netcdf odbc openexr oracle parquet pdf png postgres python qhull spatialite sqlite system-tiff test +tools webp xls zstd python_targets_python3_12 python_targets_python3_13 python_targets_python3_14 debug java verify-sig
sys-apps/systemd: acl apparmor audit boot bpf cryptsetup curl +dns-over-tls elfutils fido2 +gcrypt gnutls homed idn imds importd +kernel-install +kmod +libarchive +lz4 lzma +openssl pam passwdqc pcre pkcs11 policykit pwquality qrcode remote +resolvconf +seccomp selinux sysv-utils test tpm ukify vanilla xkb +zstd abi_x86_32 abi_x86_64 abi_x86_x32 abi_mips_n32 abi_mips_n64 abi_mips_o32 abi_s390_32 abi_s390_64 python_single_target_python3_12 python_single_target_python3_13 python_single_target_python3_14 secureboot
sys-cluster/kronosnet: doc nss +openssl lz4 lzo2 test zstd
sys-fs/erofs-utils: fuse libdeflate +lz4 +lzma selinux static-libs +threads +uuid +zlib +zstd
sys-fs/f2fs-tools: lz4 lzo selinux
sys-fs/squashfs-tools: debug lz4 lzma lzo xattr zstd
sys-fs/squashfs-tools-ng: lz4 +lzma lzo selinux +tools zstd
sys-fs/squashfuse: lz4 lzma lzo static-libs +zlib zstd
x11-wm/xpra: +X avif brotli +client +clipboard crypt csc cuda cups dbus debug doc examples gstreamer +gtk3 html ibus jpeg +lz4 mdns minimal oauth opengl openh264 pinentry pulseaudio qrcode +server sound systemd test +trayicon udev vpx webcam webp x264 xdg xinerama video_cards_nvidia python_single_target_python3_12 python_single_target_python3_13 python_single_target_python3_14 debug
app-editors/imhex: +system-llvm test lto +desktop-portal lz4 +llvm_slot_21 llvm_slot_17 llvm_slot_18 llvm_slot_19 llvm_slot_20
net-im/tuwunel: jemalloc gzip zstd lz4 bzip2 systemd brotli ldap io-uring debug +llvm_slot_21
```