### PR TITLE
Fix qkeyword search failure

### DIFF
--- a/qkeyword.c
+++ b/qkeyword.c
@@ -683,7 +683,7 @@ qkeyword_results_cb(tree_pkg_ctx *pkg_ctx, void *priv)
 			return EXIT_SUCCESS;
 
 		found = array_binsearch(metadata->email, data->qmaint,
-								(array_compar_cb *)strcmp, NULL) != NULL;
+								NULL, NULL) != NULL;
 
 		tree_close_metadata(metadata);
 		if (found)


### PR DESCRIPTION
To extend commit description, example of invalid behaviour without that patch:

```
(gdb) print((char*)data->qmaint)
$2 = 0x7fffffffdadb "gentoo.org@id.powerman.name"
(gdb) print((char*)array_get(metadata->email, 0))
$3 = 0x5555556a3d10 "gentoo.org@id.powerman.name"
(gdb) print(found)
$4 = false
```